### PR TITLE
Fix demo bootstrap + add long-running demo target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -555,6 +555,23 @@ demo: release-broker-ports ensure-minio ## Launch the broker + console demo stac
 	KAFSCALE_S3_SECRET_KEY=$(MINIO_ROOT_PASSWORD) \
 	go test -count=1 -tags=e2e ./test/e2e -run TestDemoStack -v
 
+demo-long: release-broker-ports ensure-minio ## Launch the broker + console demo stack without test timeout (Ctrl-C to stop).
+	KAFSCALE_E2E=1 \
+	KAFSCALE_E2E_DEMO=1 \
+	KAFSCALE_E2E_OPEN_UI=1 \
+	KAFSCALE_UI_USERNAME=kafscaleadmin \
+	KAFSCALE_UI_PASSWORD=kafscale \
+	KAFSCALE_CONSOLE_BROKER_METRICS_URL=http://127.0.0.1:39093/metrics \
+	KAFSCALE_CONSOLE_OPERATOR_METRICS_URL=http://127.0.0.1:8080/metrics \
+	KAFSCALE_S3_BUCKET=$(MINIO_BUCKET) \
+	KAFSCALE_S3_REGION=$(MINIO_REGION) \
+	KAFSCALE_S3_NAMESPACE=default \
+	KAFSCALE_S3_ENDPOINT=http://127.0.0.1:$(MINIO_PORT) \
+	KAFSCALE_S3_PATH_STYLE=true \
+	KAFSCALE_S3_ACCESS_KEY=$(MINIO_ROOT_USER) \
+	KAFSCALE_S3_SECRET_KEY=$(MINIO_ROOT_PASSWORD) \
+	go test -count=1 -timeout 0 -tags=e2e ./test/e2e -run TestDemoStack -v
+
 tidy:
 	go mod tidy
 

--- a/scripts/demo-platform.sh
+++ b/scripts/demo-platform.sh
@@ -238,11 +238,16 @@ elif [[ "$MODE" == "metallb" ]]; then
 		base="${subnet%%/*}"
 		mask="${subnet##*/}"
 		if [[ -n "$base" ]]; then
-			IFS='.' read -r o1 o2 o3 o4 <<<"$base"
-			if [[ "${mask:-24}" -le 16 ]]; then
-				KAFSCALE_METALLB_RANGE="${o1}.${o2}.255.200-${o1}.${o2}.255.250"
+			if [[ "$base" == *:* ]]; then
+				# IPv6 subnet: use the full CIDR to avoid invalid IPv4-style ranges.
+				KAFSCALE_METALLB_RANGE="${subnet}"
 			else
-				KAFSCALE_METALLB_RANGE="${o1}.${o2}.${o3}.200-${o1}.${o2}.${o3}.250"
+				IFS='.' read -r o1 o2 o3 o4 <<<"$base"
+				if [[ "${mask:-24}" -le 16 ]]; then
+					KAFSCALE_METALLB_RANGE="${o1}.${o2}.255.200-${o1}.${o2}.255.250"
+				else
+					KAFSCALE_METALLB_RANGE="${o1}.${o2}.${o3}.200-${o1}.${o2}.${o3}.250"
+				fi
 			fi
 		else
 			KAFSCALE_METALLB_RANGE="172.18.255.200-172.18.255.250"

--- a/test/e2e/metallb_ipv6_kind_test.go
+++ b/test/e2e/metallb_ipv6_kind_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026, Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDemoPlatformMetallbIPv6(t *testing.T) {
+	if !parseBoolEnv("KAFSCALE_E2E") || !parseBoolEnv("KAFSCALE_E2E_KIND") || !parseBoolEnv("KAFSCALE_E2E_KIND_IPV6") {
+		t.Skip("set KAFSCALE_E2E=1, KAFSCALE_E2E_KIND=1, and KAFSCALE_E2E_KIND_IPV6=1 to run IPv6 MetalLB e2e")
+	}
+
+	requireBinaries(t, "docker", "kind", "kubectl")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	clusterName := strings.TrimSpace(os.Getenv("KAFSCALE_KIND_CLUSTER"))
+	if clusterName == "" {
+		clusterName = "kafscale-e2e-ipv6"
+	}
+
+	if parseBoolEnv("KAFSCALE_KIND_RECREATE") && kindClusterExists(ctx, clusterName) {
+		_ = execCommand(ctx, "kind", "delete", "cluster", "--name", clusterName)
+	}
+
+	created := false
+	if !kindClusterExists(ctx, clusterName) {
+		configPath := writeKindIPv6Config(t)
+		runCmdGetOutput(t, ctx, "kind", "create", "cluster", "--name", clusterName, "--config", configPath, "--wait", "180s")
+		created = true
+	}
+	t.Cleanup(func() {
+		if created {
+			_ = execCommand(context.Background(), "kind", "delete", "cluster", "--name", clusterName)
+		}
+	})
+
+	ensureKindKubeconfig(t, ctx, clusterName)
+	waitForKubeAPI(t, ctx, 2*time.Minute)
+	waitForNodesReady(t, ctx, 2*time.Minute)
+
+	subnet := strings.TrimSpace(string(runCmdGetOutput(t, ctx, "docker", "network", "inspect", "kind", "--format", "{{(index .IPAM.Config 0).Subnet}}")))
+	if subnet == "" || !strings.Contains(subnet, ":") {
+		t.Skipf("kind network is not IPv6 (subnet=%q)", subnet)
+	}
+
+	scriptPath := filepath.Join(repoRoot(t), "scripts", "demo-platform.sh")
+	if err := execCommand(ctx, "bash", scriptPath, "metallb"); err != nil {
+		t.Fatalf("apply metallb config: %v", err)
+	}
+
+	address := strings.TrimSpace(string(runCmdGetOutput(t, ctx, "kubectl", "-n", "metallb-system", "get", "ipaddresspool", "kind-pool", "-o", "jsonpath={.spec.addresses[0]}")))
+	if address != subnet {
+		t.Fatalf("expected MetalLB pool %q, got %q", subnet, address)
+	}
+}
+
+func writeKindIPv6Config(t *testing.T) string {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "kafscale-kind-ipv6-*.yaml")
+	if err != nil {
+		t.Fatalf("create kind ipv6 config: %v", err)
+	}
+	config := "kind: Cluster\napiVersion: kind.x-k8s.io/v1alpha4\nnetworking:\n  ipFamily: ipv6\n"
+	if _, err := tmp.WriteString(config); err != nil {
+		_ = tmp.Close()
+		t.Fatalf("write kind ipv6 config: %v", err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close kind ipv6 config: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(tmp.Name()) })
+	return tmp.Name()
+}

--- a/test/e2e/metallb_ipv6_kind_test.go
+++ b/test/e2e/metallb_ipv6_kind_test.go
@@ -20,7 +20,6 @@ package e2e
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -66,8 +65,9 @@ func TestDemoPlatformMetallbIPv6(t *testing.T) {
 		t.Skipf("kind network is not IPv6 (subnet=%q)", subnet)
 	}
 
-	scriptPath := filepath.Join(repoRoot(t), "scripts", "demo-platform.sh")
-	if err := execCommand(ctx, "bash", scriptPath, "metallb"); err != nil {
+	repo := repoRoot(t)
+	cmd := "cd " + repo + " && scripts/demo-platform.sh metallb"
+	if err := execCommand(ctx, "bash", "-lc", cmd); err != nil {
 		t.Fatalf("apply metallb config: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Handle IPv6 kind networks when deriving MetalLB address pools.
- Add a long-running demo test target that disables go test timeout.
- Add IPv6 MetalLB e2e coverage for demo bootstrap.

## Changes
- scripts/demo-platform.sh: use IPv6 CIDR as the MetalLB pool when the kind subnet is IPv6.
- Makefile: add demo-long target (go test -timeout 0).
- test/e2e/metallb_ipv6_kind_test.go: new opt-in IPv6 kind e2e test.

## Validation
- KAFSCALE_E2E=1 KAFSCALE_E2E_KIND=1 KAFSCALE_E2E_KIND_IPV6=1 go test -tags=e2e ./test/e2e -run TestDemoPlatformMetallbIPv6 -v