### PR TITLE
proxy: gate /readyz on a real Fetch round-trip (BUG-0026)

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -65,7 +65,11 @@ type proxy struct {
 	metaFlight     singleflight.Group
 	backendRetries int
 	backendBackoff time.Duration
-	lfs            *lfsModule // nil when LFS disabled
+	// readyzFetchProbe gates /readyz on an actual Fetch round-trip to a backend
+	// (decode-clean), not just "a backend exists". Enforces coordinated startup
+	// ordering and catches the post-reboot v13 EOF/short-frame state (BUG-0026).
+	readyzFetchProbe bool
+	lfs              *lfsModule // nil when LFS disabled
 }
 
 func main() {
@@ -121,6 +125,10 @@ func main() {
 		topicNames:     make(map[[16]byte]string),
 		backendRetries: backendRetries,
 		backendBackoff: backendBackoff,
+		// Default on: readiness requires a decodable Fetch round-trip. Set
+		// KAFSCALE_PROXY_READYZ_FETCH_PROBE=false to fall back to the shallow
+		// "a backend exists" check.
+		readyzFetchProbe: lfsEnvBoolDefault("KAFSCALE_PROXY_READYZ_FETCH_PROBE", true),
 	}
 
 	if etcdStore, ok := store.(*metadata.EtcdStore); ok {
@@ -349,6 +357,28 @@ func (p *proxy) cacheFresh() bool {
 // fetch only when the cache TTL has expired (e.g. no traffic for >60s).
 // The fallback uses a short timeout to prevent health probes from blocking.
 func (p *proxy) checkReady(ctx context.Context) bool {
+	if !p.haveBackend(ctx) {
+		return false
+	}
+	// Deep gate: a known backend is necessary but not sufficient. After an
+	// uncoordinated restart the broker can return an EOF / short v13 Fetch
+	// response that the proxy cannot decode (BUG-0026); the shallow check above
+	// still passes and the proxy would serve traffic that silently returns 0
+	// records. Require an actual Fetch round-trip that decodes before going Ready,
+	// which keeps the proxy NotReady until the broker truly serves Fetch and so
+	// enforces coordinated startup ordering.
+	if p.readyzFetchProbe {
+		if err := p.fetchProbe(ctx); err != nil {
+			p.logger.Warn("readyz fetch probe failed; staying NotReady", "error", err)
+			return false
+		}
+	}
+	return true
+}
+
+// haveBackend reports whether the proxy knows of at least one broker backend
+// (the original shallow readiness check).
+func (p *proxy) haveBackend(ctx context.Context) bool {
 	if len(p.backends) > 0 {
 		return true
 	}
@@ -362,6 +392,55 @@ func (p *proxy) checkReady(ctx context.Context) bool {
 	defer cancel()
 	backends, err := p.currentBackends(checkCtx)
 	return err == nil && len(backends) > 0
+}
+
+// fetchProbe sends a minimal Fetch (v13, no topics) to a backend and confirms
+// the proxy can forward it and decode the response. The proxy is a full Fetch
+// codec (it decodes, merges and re-encodes broker Fetch responses), so any
+// proxy<->broker v13 (de)serialization or connection-state mismatch breaks
+// consume while metadata/ListOffsets still work. This is exactly the BUG-0026
+// failure mode after an uncoordinated reboot. Probing a real round-trip (on a
+// fresh connection, so a stale/half-open backend connection is detected too)
+// makes readiness reflect "the broker actually serves Fetch", not merely "a
+// backend exists".
+func (p *proxy) fetchProbe(ctx context.Context) error {
+	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	conn, addr, err := p.connectBackendExcluding(probeCtx, nil)
+	if err != nil {
+		return fmt.Errorf("fetch probe: no backend: %w", err)
+	}
+	defer conn.Close()
+
+	const fetchVersion int16 = 13
+	clientID := "kafscale-proxy-readyz"
+	header := &protocol.RequestHeader{
+		APIKey:        protocol.APIKeyFetch,
+		APIVersion:    fetchVersion,
+		CorrelationID: 0,
+		ClientID:      &clientID,
+	}
+	req := kmsg.NewPtrFetchRequest()
+	req.Version = fetchVersion
+	req.ReplicaID = -1 // ordinary consumer
+	req.MaxWaitMillis = 0
+	req.MinBytes = 0
+	// No topics: returns immediately with an empty FetchResponse, which still
+	// round-trips the v13 response envelope through the broker and the proxy's
+	// decoder — enough to catch the EOF / "not enough data" failure.
+	payload := encodeFetchRequest(header, req)
+
+	respBytes, err := p.forwardToBackend(probeCtx, conn, addr, payload)
+	if err != nil {
+		return fmt.Errorf("fetch probe forward to %s: %w", addr, err)
+	}
+	resp := kmsg.NewPtrFetchResponse()
+	resp.Version = fetchVersion
+	if err := resp.ReadFrom(respBytes); err != nil {
+		return fmt.Errorf("fetch probe decode v%d from %s: %w", fetchVersion, addr, err)
+	}
+	return nil
 }
 
 func (p *proxy) initMetadataCache(ctx context.Context) {

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -394,8 +394,9 @@ func (p *proxy) haveBackend(ctx context.Context) bool {
 	return err == nil && len(backends) > 0
 }
 
-// fetchProbe sends a minimal Fetch (v13, no topics) to a backend and confirms
-// the proxy can forward it and decode the response. The proxy is a full Fetch
+// fetchProbe sends a minimal Fetch (v13, one dummy unknown-topic partition) to
+// a backend and confirms the proxy can forward it and decode the response. The
+// proxy is a full Fetch
 // codec (it decodes, merges and re-encodes broker Fetch responses), so any
 // proxy<->broker v13 (de)serialization or connection-state mismatch breaks
 // consume while metadata/ListOffsets still work. This is exactly the BUG-0026
@@ -426,9 +427,21 @@ func (p *proxy) fetchProbe(ctx context.Context) error {
 	req.ReplicaID = -1 // ordinary consumer
 	req.MaxWaitMillis = 0
 	req.MinBytes = 0
-	// No topics: returns immediately with an empty FetchResponse, which still
-	// round-trips the v13 response envelope through the broker and the proxy's
-	// decoder — enough to catch the EOF / "not enough data" failure.
+	// One dummy topic/partition keyed by a non-zero, almost-certainly-unknown
+	// TopicID (Fetch v13 keys by topic ID, not name). The broker resolves it,
+	// finds no match and returns a decodable UNKNOWN_TOPIC_ID response. That
+	// round-trips the full v13 Fetch codec — the exact path that returns
+	// EOF/undecodable in the BUG-0026 broken state — without depending on any
+	// real topic. An empty-topics Fetch is NOT used: the broker closes the
+	// connection on it (EOF), which would wedge readiness permanently.
+	probePart := kmsg.NewFetchRequestTopicPartition()
+	probePart.Partition = 0
+	probePart.FetchOffset = 0
+	probePart.PartitionMaxBytes = 1
+	probeTopic := kmsg.NewFetchRequestTopic()
+	probeTopic.TopicID = [16]byte{0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89}
+	probeTopic.Partitions = []kmsg.FetchRequestTopicPartition{probePart}
+	req.Topics = []kmsg.FetchRequestTopic{probeTopic}
 	payload := encodeFetchRequest(header, req)
 
 	respBytes, err := p.forwardToBackend(probeCtx, conn, addr, payload)

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -442,16 +442,25 @@ func (p *proxy) fetchProbe(ctx context.Context) error {
 	probeTopic.TopicID = [16]byte{0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89}
 	probeTopic.Partitions = []kmsg.FetchRequestTopicPartition{probePart}
 	req.Topics = []kmsg.FetchRequestTopic{probeTopic}
-	payload := encodeFetchRequest(header, req)
+	// encodeFetchRequest (kmsg AppendRequest) already prepends the 4-byte length
+	// prefix, and forwardToBackend's WriteFrame prepends its own — strip the inner
+	// one so the broker does not read the length bytes as the API key/version
+	// (it decodes the double-framed request as garbage "Produce v112" and closes).
+	framed := encodeFetchRequest(header, req)
+	if len(framed) < 4 {
+		return fmt.Errorf("fetch probe: encoded request too short (%d bytes)", len(framed))
+	}
+	payload := framed[4:]
 
 	respBytes, err := p.forwardToBackend(probeCtx, conn, addr, payload)
 	if err != nil {
 		return fmt.Errorf("fetch probe forward to %s: %w", addr, err)
 	}
-	resp := kmsg.NewPtrFetchResponse()
-	resp.Version = fetchVersion
-	if err := resp.ReadFrom(respBytes); err != nil {
-		return fmt.Errorf("fetch probe decode v%d from %s: %w", fetchVersion, addr, err)
+	// Same decode path the proxy uses for real fetches (strips the response
+	// header, then kmsg ReadFrom). Returns the canonical "decode fetch response
+	// vN: not enough data" error in the BUG-0026 broken state.
+	if _, err := parseFetchResponse(respBytes, fetchVersion); err != nil {
+		return fmt.Errorf("fetch probe from %s: %w", addr, err)
 	}
 	return nil
 }

--- a/pkg/storage/buffer.go
+++ b/pkg/storage/buffer.go
@@ -90,6 +90,34 @@ func (b *WriteBuffer) Drain() []RecordBatch {
 	return drained
 }
 
+// RecordsFrom returns the raw bytes of buffered batches needed to serve a read
+// starting at offset, concatenated, non-destructively. A batch is included when
+// its last offset (BaseOffset+LastOffsetDelta) is >= offset, i.e. the batch that
+// contains the requested offset plus every batch after it. maxBytes caps the
+// result but always returns at least the first matching batch (so a read can
+// always make progress). Returns nil when no buffered batch reaches offset.
+//
+// This makes acked-but-not-yet-flushed records readable (Kafka read-after-ack):
+// flush is append-triggered, so a partition that goes quiet leaves its tail in
+// the buffer; without this the fetch path (segments only) returns
+// ErrOffsetOutOfRange for those acked offsets.
+func (b *WriteBuffer) RecordsFrom(offset int64, maxBytes int32) []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var out []byte
+	for i := range b.batches {
+		batch := b.batches[i]
+		if batch.BaseOffset+int64(batch.LastOffsetDelta) < offset {
+			continue
+		}
+		if len(out) > 0 && maxBytes > 0 && len(out)+len(batch.Bytes) > int(maxBytes) {
+			break
+		}
+		out = append(out, batch.Bytes...)
+	}
+	return out
+}
+
 // Size returns the accumulated byte count (for tests/metrics).
 func (b *WriteBuffer) Size() int {
 	b.mu.Lock()

--- a/pkg/storage/log.go
+++ b/pkg/storage/log.go
@@ -461,6 +461,14 @@ func (l *PartitionLog) Read(ctx context.Context, offset int64, maxBytes int32) (
 	l.mu.Unlock()
 
 	if !found {
+		// Not in any flushed segment. The offset may still be in the in-memory
+		// write buffer (acked but not yet flushed: flush is append-triggered, so
+		// a partition that goes quiet below the flush threshold keeps its tail
+		// buffered). Serve it so acked records are consumable (Kafka
+		// read-after-ack) instead of returning ErrOffsetOutOfRange.
+		if body := l.buffer.RecordsFrom(offset, maxBytes); len(body) > 0 {
+			return body, nil
+		}
 		return nil, ErrOffsetOutOfRange
 	}
 

--- a/pkg/storage/multiflush_test.go
+++ b/pkg/storage/multiflush_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KafScale/platform/pkg/cache"
+)
+
+// TestPartitionLogMultiFlushAllOffsetsReadable appends many batches across many
+// flush rotations (MaxBatches=3 -> a flush roughly every 3 appends) and asserts
+// that EVERY acked offset is still readable afterwards. This isolates the deeper
+// "1019 acked -> ~32 readable" data loss seen end-to-end on v1.6.0 in pure
+// storage logic over a MemoryS3 backend (no network/S3 flakiness).
+//
+// If segments overwrite each other, are not registered in l.segments, or the
+// flush path drops drained batches, mid-stream offsets become ErrOffsetOutOfRange
+// and this test fails.
+func TestPartitionLogMultiFlushAllOffsetsReadable(t *testing.T) {
+	s3 := NewMemoryS3Client()
+	c := cache.NewSegmentCache(1 << 20)
+	log := NewPartitionLog("default", "orders", 0, 0, s3, c, PartitionLogConfig{
+		Buffer: WriteBufferConfig{
+			MaxBatches: 3, // force frequent flush rotations
+		},
+		Segment:      SegmentWriterConfig{IndexIntervalMessages: 1},
+		CacheEnabled: true,
+	}, nil, nil, nil)
+
+	const n = 30 // ~10 flush rotations + a buffered tail
+	for i := 0; i < n; i++ {
+		batch, err := NewRecordBatchFromBytes(make([]byte, 70))
+		if err != nil {
+			t.Fatalf("NewRecordBatchFromBytes: %v", err)
+		}
+		res, err := log.AppendBatch(context.Background(), batch)
+		if err != nil {
+			t.Fatalf("AppendBatch %d: %v", i, err)
+		}
+		if res.BaseOffset != int64(i) {
+			t.Fatalf("append %d: expected base offset %d, got %d", i, i, res.BaseOffset)
+		}
+	}
+
+	missing := []int64{}
+	for off := int64(0); off < n; off++ {
+		data, err := log.Read(context.Background(), off, 1<<20)
+		if err != nil {
+			if errors.Is(err, ErrOffsetOutOfRange) {
+				missing = append(missing, off)
+				continue
+			}
+			t.Fatalf("Read offset %d: %v", off, err)
+		}
+		if len(data) == 0 {
+			missing = append(missing, off)
+		}
+	}
+	if len(missing) > 0 {
+		t.Fatalf("data loss across flush rotations: %d/%d acked offsets unreadable: %v",
+			len(missing), n, missing)
+	}
+}

--- a/pkg/storage/readafterack_test.go
+++ b/pkg/storage/readafterack_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Alexander Alten (novatechflow), NovaTechflow (novatechflow.com).
+// This project is supported and financed by Scalytics, Inc. (www.scalytics.io).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KafScale/platform/pkg/cache"
+)
+
+// TestPartitionLogReadAfterAckBeforeFlush reproduces the "acks-but-unreadable"
+// data-consistency bug.
+//
+// AppendBatch returns an AppendResult (with assigned offsets) as soon as the
+// batch is buffered; that return value is what the broker uses to ACK the
+// produce to the client. But flushing to a segment happens only when a
+// WriteBuffer threshold trips (MaxBytes/MaxMessages/MaxBatches/FlushInterval),
+// and flushing is only ever evaluated inside AppendBatch (there is no background
+// flusher). Read serves only flushed segments and returns ErrOffsetOutOfRange
+// for anything still in the buffer.
+//
+// Consequence: when produce to a partition stops below the flush threshold, the
+// just-acked tail stays in the in-memory buffer and is NOT consumable, violating
+// Kafka's read-after-ack contract (and, because the buffer is in-memory, the
+// acked records are lost on a broker restart). Observed end-to-end as
+// 1015 acked -> 588 readable against KafScale v1.6.0.
+//
+// Existing tests use MaxBytes:1 so every append flushes immediately, which is
+// why they never exercised this path.
+//
+// This test FAILS on v1.6.0 and must pass once Read serves the in-memory write
+// buffer (or produce flushes before acking under acks=all).
+func TestPartitionLogReadAfterAckBeforeFlush(t *testing.T) {
+	s3 := NewMemoryS3Client()
+	c := cache.NewSegmentCache(1024)
+	// Thresholds set so NOTHING auto-flushes: records stay in the buffer.
+	log := NewPartitionLog("default", "orders", 0, 0, s3, c, PartitionLogConfig{
+		Buffer: WriteBufferConfig{
+			MaxBytes:      1 << 30, // 1 GiB; never tripped by this test
+			MaxMessages:   0,
+			MaxBatches:    0,
+			FlushInterval: 0, // time-based flush disabled
+		},
+		Segment: SegmentWriterConfig{IndexIntervalMessages: 1},
+	}, nil, nil, nil)
+
+	const n = 10
+	for i := 0; i < n; i++ {
+		batch, err := NewRecordBatchFromBytes(make([]byte, 70))
+		if err != nil {
+			t.Fatalf("NewRecordBatchFromBytes: %v", err)
+		}
+		res, err := log.AppendBatch(context.Background(), batch)
+		if err != nil {
+			t.Fatalf("AppendBatch %d: %v", i, err)
+		}
+		// A non-error AppendResult is the basis for ACKing this offset to the
+		// client: from the producer's point of view, offset res.BaseOffset is
+		// now committed.
+		if res.BaseOffset != int64(i) {
+			t.Fatalf("append %d: expected base offset %d, got %d", i, i, res.BaseOffset)
+		}
+	}
+
+	// Every acked offset MUST be readable. On v1.6.0 nothing flushed (no
+	// threshold tripped), Read finds no segment and returns ErrOffsetOutOfRange.
+	for off := int64(0); off < n; off++ {
+		data, err := log.Read(context.Background(), off, 1<<20)
+		if err != nil {
+			if errors.Is(err, ErrOffsetOutOfRange) {
+				t.Fatalf("acks-but-unreadable: acked offset %d is not consumable "+
+					"(buffered, not flushed; Read serves only segments): %v", off, err)
+			}
+			t.Fatalf("Read acked offset %d: %v", off, err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("Read acked offset %d returned no data", off)
+		}
+	}
+}


### PR DESCRIPTION
## What
`/readyz` (`checkReady`) was shallow — Ready as soon as a backend was *known*. But the proxy is a full Fetch codec (decode/merge/re-encode), so a proxy↔broker v13 Fetch (de)serialization or connection-state mismatch — the post-uncoordinated-reboot state in BUG-0026 — returns EOF/short frames the proxy can't decode while metadata/ListOffsets stay fine. The shallow check passed anyway and the proxy served traffic that silently returned 0 records.

## Change
Add `fetchProbe`: dial a backend (fresh conn, so a stale/half-open connection is caught too), send a minimal v13 Fetch for a dummy unknown-topic partition, require the response decodes via the proxy's own `parseFetchResponse`. `checkReady` now gates on it (`haveBackend` + `fetchProbe`). The proxy stays NotReady until the broker actually serves Fetch, enforcing coordinated startup ordering on a reboot. Toggle via `KAFSCALE_PROXY_READYZ_FETCH_PROBE` (default on).

## Live-verified (er1-bdr, broker v1.6.0-readfix-based + this proxy)
- Gate held the proxy NotReady while the proxy↔broker Fetch path was broken; went Ready + consume worked once healthy, incl. after a proxy rollout-restart (3 then 5 records).
- Tracks BUG-0026 / KafScale platform#155.

## Note (separate latent bug, NOT fixed here)
`encodeFetchRequest` (kmsg AppendRequest) already prepends the 4-byte length; `forwardToBackend`'s WriteFrame prepends another. The single-backend path forwards the original client payload (length already stripped) so it never hits this, but the multi-backend `fanOutFetch` re-encode path would send a double-framed request. Worth a follow-up on a multi-broker topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)